### PR TITLE
Fix ChatInterface init error

### DIFF
--- a/interface_demo.py
+++ b/interface_demo.py
@@ -8,13 +8,10 @@ def respond(message: str, history: list[tuple[str, str]]) -> str:
 
 demo = gr.ChatInterface(
     fn=respond,
-    title="Chatterbox Speech Chat Demo",
+    title="Chatterbox Chat Demo",
     description=(
-        "Speak into your microphone and hear the demo repeat your words. "
-        "This uses Gradio's built-in Whisper and gTTS for speech input and output."
-    ), 
-    input_audio="microphone",
-    output_audio=True, 
+        "Type into the textbox and see the demo repeat your words."
+    ),
 )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- clean up `interface_demo` by removing unsupported ChatInterface `input_audio`/`output_audio`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_6858d0fb673c832eb127e9a6fbef5d05